### PR TITLE
Work on nested files

### DIFF
--- a/test_tigknil
+++ b/test_tigknil
@@ -22,6 +22,7 @@ COMMIT=$(git rev-parse HEAD)
 # Test cases
 git remote set-url origin "git@github.com:Sjord/tigknil.git"
 diff <($TIGKNIL test.txt) - <<< "https://github.com/Sjord/tigknil/blob/$COMMIT/test.txt"
+diff <($TIGKNIL testdir/nested.txt) - <<< "https://github.com/Sjord/tigknil/blob/$COMMIT/testdir/nested.txt"
 
 # Done
 echo Tests passed

--- a/tigknil
+++ b/tigknil
@@ -3,8 +3,9 @@
 for path in "$@"
 do
     DIRECTORY=$(dirname "$path")
+    FILENAME=$(basename "$path")
     GIT_URL=$(git -C "$DIRECTORY" remote get-url origin)
-    RELATIVE_PATH=$(git -C "$DIRECTORY" ls-files --full-name "$path")
+    RELATIVE_PATH=$(git -C "$DIRECTORY" ls-files --full-name "$FILENAME")
     COMMIT=$(git -C "$DIRECTORY" rev-parse HEAD)
     HTTPS_URL=$(sed -e 's~:~/~' -e 's~git@~https://~' -e 's~\.git$~~' <<< "$GIT_URL")
     echo "$HTTPS_URL/blob/$COMMIT/$RELATIVE_PATH"


### PR DESCRIPTION
We are already relative to $DIRECTORY, so only use the basename of the path.